### PR TITLE
Fix C99 incompatibilities in examples

### DIFF
--- a/EXAMPLE/pclinsol.c
+++ b/EXAMPLE/pclinsol.c
@@ -18,6 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_cdefs.h"
 
+#include <unistd.h>
+
+int
 main(int argc, char *argv[])
 {
     SuperMatrix   A;

--- a/EXAMPLE/pclinsolx.c
+++ b/EXAMPLE/pclinsolx.c
@@ -18,7 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_cdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pclinsolx1.c
+++ b/EXAMPLE/pclinsolx1.c
@@ -27,7 +27,9 @@ at the top-level directory.
  */
 #include "slu_mt_cdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, A1, L, U;

--- a/EXAMPLE/pclinsolx2.c
+++ b/EXAMPLE/pclinsolx2.c
@@ -25,7 +25,9 @@ at the top-level directory.
  */
 #include "slu_mt_cdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pcrepeat.c
+++ b/EXAMPLE/pcrepeat.c
@@ -31,7 +31,9 @@ at the top-level directory.
  */
 #include "slu_mt_cdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pcspmd.c
+++ b/EXAMPLE/pcspmd.c
@@ -28,6 +28,7 @@ at the top-level directory.
  * 
  */
 #include <stdlib.h> /* for getenv and atoi */
+#include <unistd.h>
 #include "slu_mt_cdefs.h"
 
 
@@ -57,6 +58,7 @@ typedef struct {
 void *cspmd(void *);
 void *pcdot_thread(void *);
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pdlinsol.c
+++ b/EXAMPLE/pdlinsol.c
@@ -18,6 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_ddefs.h"
 
+#include <unistd.h>
+
+int
 main(int argc, char *argv[])
 {
     SuperMatrix   A;

--- a/EXAMPLE/pdlinsolx.c
+++ b/EXAMPLE/pdlinsolx.c
@@ -18,7 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_ddefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pdlinsolx1.c
+++ b/EXAMPLE/pdlinsolx1.c
@@ -27,7 +27,9 @@ at the top-level directory.
  */
 #include "slu_mt_ddefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, A1, L, U;

--- a/EXAMPLE/pdlinsolx2.c
+++ b/EXAMPLE/pdlinsolx2.c
@@ -25,7 +25,9 @@ at the top-level directory.
  */
 #include "slu_mt_ddefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pdrepeat.c
+++ b/EXAMPLE/pdrepeat.c
@@ -31,7 +31,9 @@ at the top-level directory.
  */
 #include "slu_mt_ddefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pdspmd.c
+++ b/EXAMPLE/pdspmd.c
@@ -28,6 +28,7 @@ at the top-level directory.
  * 
  */
 #include <stdlib.h> /* for getenv and atoi */
+#include <unistd.h>
 #include "slu_mt_ddefs.h"
 
 
@@ -57,6 +58,7 @@ typedef struct {
 void *dspmd(void *);
 void *pddot_thread(void *);
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pslinsol.c
+++ b/EXAMPLE/pslinsol.c
@@ -18,6 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_sdefs.h"
 
+#include <unistd.h>
+
+int
 main(int argc, char *argv[])
 {
     SuperMatrix   A;

--- a/EXAMPLE/pslinsolx.c
+++ b/EXAMPLE/pslinsolx.c
@@ -18,7 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_sdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pslinsolx1.c
+++ b/EXAMPLE/pslinsolx1.c
@@ -27,7 +27,9 @@ at the top-level directory.
  */
 #include "slu_mt_sdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, A1, L, U;

--- a/EXAMPLE/pslinsolx2.c
+++ b/EXAMPLE/pslinsolx2.c
@@ -25,7 +25,9 @@ at the top-level directory.
  */
 #include "slu_mt_sdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/psrepeat.c
+++ b/EXAMPLE/psrepeat.c
@@ -31,7 +31,9 @@ at the top-level directory.
  */
 #include "slu_mt_sdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/psspmd.c
+++ b/EXAMPLE/psspmd.c
@@ -28,6 +28,7 @@ at the top-level directory.
  * 
  */
 #include <stdlib.h> /* for getenv and atoi */
+#include <unistd.h>
 #include "slu_mt_sdefs.h"
 
 
@@ -57,6 +58,7 @@ typedef struct {
 void *sspmd(void *);
 void *psdot_thread(void *);
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pzlinsol.c
+++ b/EXAMPLE/pzlinsol.c
@@ -18,6 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_zdefs.h"
 
+#include <unistd.h>
+
+int
 main(int argc, char *argv[])
 {
     SuperMatrix   A;

--- a/EXAMPLE/pzlinsolx.c
+++ b/EXAMPLE/pzlinsolx.c
@@ -18,7 +18,9 @@ at the top-level directory.
  */
 #include "slu_mt_zdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pzlinsolx1.c
+++ b/EXAMPLE/pzlinsolx1.c
@@ -27,7 +27,9 @@ at the top-level directory.
  */
 #include "slu_mt_zdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, A1, L, U;

--- a/EXAMPLE/pzlinsolx2.c
+++ b/EXAMPLE/pzlinsolx2.c
@@ -25,7 +25,9 @@ at the top-level directory.
  */
 #include "slu_mt_zdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, L, U;

--- a/EXAMPLE/pzrepeat.c
+++ b/EXAMPLE/pzrepeat.c
@@ -31,7 +31,9 @@ at the top-level directory.
  */
 #include "slu_mt_zdefs.h"
 
+#include <unistd.h>
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;

--- a/EXAMPLE/pzspmd.c
+++ b/EXAMPLE/pzspmd.c
@@ -28,6 +28,7 @@ at the top-level directory.
  * 
  */
 #include <stdlib.h> /* for getenv and atoi */
+#include <unistd.h>
 #include "slu_mt_zdefs.h"
 
 
@@ -57,6 +58,7 @@ typedef struct {
 void *zspmd(void *);
 void *pzdot_thread(void *);
 
+int
 main(int argc, char *argv[])
 {
     SuperMatrix A, AC, L, U, B;


### PR DESCRIPTION
Declare the return type of main as int, and include <unistd.h> for the getopt function prototype.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
