### PR TITLE
Fix -Wimplicit-function-declaration

### DIFF
--- a/SRC/pdgssvx.c
+++ b/SRC/pdgssvx.c
@@ -10,6 +10,7 @@ at the top-level directory.
 */
 
 #include "slu_mt_ddefs.h"
+#include "slu_mt_util.h"
 
 
 void

--- a/SRC/pzgssvx.c
+++ b/SRC/pzgssvx.c
@@ -10,6 +10,7 @@ at the top-level directory.
 */
 
 #include "slu_mt_zdefs.h"
+#include "slu_mt_util.h"
 
 
 void


### PR DESCRIPTION
Fixes a small declaration issue:
```
psgssvx.c:580:2: error: call to undeclared function 'sp_colorder'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
2023-11-06T21:55:20.4546880Z         sp_colorder(AA, perm_c, superlumt_options, &AC);
```