### PR TITLE
CMake: Add LONGINT option

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Build
       run: |
         cmake -DCMAKE_C_FLAGS="-Wall -Wextra -Wpedantic" -DCMAKE_INSTALL_PREFIX=$PWD/install .
-        make -j2
+        make -j4
     - name: Test
-      run: ctest -R LA --output-on-failure -j2 --schedule-random --timeout 500
+      run: ctest --output-on-failure -j4 --schedule-random --timeout 500
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,6 +102,7 @@ else ()
   message (SEND_ERROR "invalid PLAT setting")
 endif ()
 
+option (LONGINT "use 64-bit integers for indexing sparse matrices (default is 32-bit)" OFF)
 
 enable_language(C)
 if (enable_fortran)

--- a/EXAMPLE/pclinsol.c
+++ b/EXAMPLE/pclinsol.c
@@ -41,7 +41,8 @@ main(int argc, char *argv[])
     trans_t  trans;
     complex   *xact, *rhs;
     superlu_memusage_t   superlu_memusage;
-    void   parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *procs,
+                            int_t *n, int_t *b, int_t *w, int_t *r, int_t *maxsup);
 
     nrhs              = 1;
     trans             = NOTRANS;

--- a/EXAMPLE/pclinsolx.c
+++ b/EXAMPLE/pclinsolx.c
@@ -46,7 +46,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork,
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -218,7 +220,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/pclinsolx1.c
+++ b/EXAMPLE/pclinsolx1.c
@@ -55,7 +55,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -276,7 +278,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/pclinsolx2.c
+++ b/EXAMPLE/pclinsolx2.c
@@ -54,7 +54,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -234,7 +236,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/pcrepeat.c
+++ b/EXAMPLE/pcrepeat.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     complex      *rhsb, *xact;
     Gstat_t Gstat;
     flops_t     flopcnt;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pcspmd.c
+++ b/EXAMPLE/pcspmd.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
     pthread_t *thread_id;
     void      *status;
 #endif
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pdlinsol.c
+++ b/EXAMPLE/pdlinsol.c
@@ -41,7 +41,8 @@ main(int argc, char *argv[])
     trans_t  trans;
     double   *xact, *rhs;
     superlu_memusage_t   superlu_memusage;
-    void   parse_command_line();
+    void   parse_command_line(int argc, char *argv[], int_t *procs, int_t *n,
+                              int_t *b, int_t *w, int_t *r, int_t *maxsup);
 
     nrhs              = 1;
     trans             = NOTRANS;

--- a/EXAMPLE/pdlinsolx.c
+++ b/EXAMPLE/pdlinsolx.c
@@ -46,7 +46,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pdlinsolx1.c
+++ b/EXAMPLE/pdlinsolx1.c
@@ -55,7 +55,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pdlinsolx2.c
+++ b/EXAMPLE/pdlinsolx2.c
@@ -54,7 +54,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pdrepeat.c
+++ b/EXAMPLE/pdrepeat.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     double      *rhsb, *xact;
     Gstat_t Gstat;
     flops_t     flopcnt;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pdspmd.c
+++ b/EXAMPLE/pdspmd.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
     pthread_t *thread_id;
     void      *status;
 #endif
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pslinsol.c
+++ b/EXAMPLE/pslinsol.c
@@ -41,7 +41,8 @@ main(int argc, char *argv[])
     trans_t  trans;
     float   *xact, *rhs;
     superlu_memusage_t   superlu_memusage;
-    void   parse_command_line();
+    void   parse_command_line(int argc, char *argv[], int_t *procs, int_t *n,
+                              int_t *b, int_t *w, int_t *r, int_t *maxsup);
 
     nrhs              = 1;
     trans             = NOTRANS;

--- a/EXAMPLE/pslinsolx.c
+++ b/EXAMPLE/pslinsolx.c
@@ -46,7 +46,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -218,7 +220,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/pslinsolx1.c
+++ b/EXAMPLE/pslinsolx1.c
@@ -55,7 +55,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -276,7 +278,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/pslinsolx2.c
+++ b/EXAMPLE/pslinsolx2.c
@@ -54,7 +54,9 @@ main(int argc, char *argv[])
     float      *ferr, *berr;
     float      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, float *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;
@@ -234,7 +236,7 @@ main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
-		   int_t *w, int_t *relax, double *u, fact_t *fact, 
+		   int_t *w, int_t *relax, float *u, fact_t *fact, 
 		   trans_t *trans, yes_no_t *refact, equed_t *equed)
 {
     int c;

--- a/EXAMPLE/psrepeat.c
+++ b/EXAMPLE/psrepeat.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     float      *rhsb, *xact;
     Gstat_t Gstat;
     flops_t     flopcnt;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/psspmd.c
+++ b/EXAMPLE/psspmd.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
     pthread_t *thread_id;
     void      *status;
 #endif
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pzlinsol.c
+++ b/EXAMPLE/pzlinsol.c
@@ -41,7 +41,8 @@ main(int argc, char *argv[])
     trans_t  trans;
     doublecomplex   *xact, *rhs;
     superlu_memusage_t   superlu_memusage;
-    void   parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *procs, int_t *n,
+                            int_t *b, int_t *w, int_t *r, int_t *maxsup);
 
     nrhs              = 1;
     trans             = NOTRANS;

--- a/EXAMPLE/pzlinsolx.c
+++ b/EXAMPLE/pzlinsolx.c
@@ -46,7 +46,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pzlinsolx1.c
+++ b/EXAMPLE/pzlinsolx1.c
@@ -55,8 +55,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
-
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
     /* Default parameters to control factorization. */
     nprocs = 1;
     fact  = EQUILIBRATE;

--- a/EXAMPLE/pzlinsolx2.c
+++ b/EXAMPLE/pzlinsolx2.c
@@ -54,7 +54,9 @@ main(int argc, char *argv[])
     double      *ferr, *berr;
     double      u, drop_tol, rpg, rcond;
     superlu_memusage_t superlu_memusage;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs, int_t *lwork, 
+                            int_t *w, int_t *relax, double *u, fact_t *fact, 
+                            trans_t *trans, yes_no_t *refact, equed_t *equed);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pzrepeat.c
+++ b/EXAMPLE/pzrepeat.c
@@ -59,7 +59,7 @@ main(int argc, char *argv[])
     doublecomplex      *rhsb, *xact;
     Gstat_t Gstat;
     flops_t     flopcnt;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/EXAMPLE/pzspmd.c
+++ b/EXAMPLE/pzspmd.c
@@ -94,7 +94,7 @@ main(int argc, char *argv[])
     pthread_t *thread_id;
     void      *status;
 #endif
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], int_t *nprocs);
 
     /* Default parameters to control factorization. */
     nprocs = 1;

--- a/SRC/CMakeLists.txt
+++ b/SRC/CMakeLists.txt
@@ -20,6 +20,10 @@ elseif (PLAT STREQUAL "_OPENMP")
   target_link_libraries (superlu_mt${PLAT} PRIVATE OpenMP::OpenMP_C)
 endif ()
 
+if (LONGINT)
+  target_compile_definitions (superlu_mt${PLAT} PUBLIC _LONGINT)
+endif ()
+
 target_include_directories (superlu_mt${PLAT} PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories (superlu_mt${PLAT} INTERFACE $<INSTALL_INTERFACE:include>)
 install (TARGETS superlu_mt${PLAT} DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/SRC/creadmt.c
+++ b/SRC/creadmt.c
@@ -40,8 +40,8 @@ creadmt(int_t *m, int_t *n, int_t *nonz, complex **nzval, int_t **rowind, int_t 
     int    lasta;
     char   title[TLEN];
     complex *a;
-    int    *asub;
-    int    *xa;
+    int_t    *asub;
+    int_t    *xa;
     
     /* 	Matrix format:
      *         up to 60 characters           title

--- a/SRC/dreadmt.c
+++ b/SRC/dreadmt.c
@@ -40,8 +40,8 @@ dreadmt(int_t *m, int_t *n, int_t *nonz, double **nzval, int_t **rowind, int_t *
     int    lasta;
     char   title[TLEN];
     double *a;
-    int    *asub;
-    int    *xa;
+    int_t    *asub;
+    int_t    *xa;
     
     /* 	Matrix format:
      *         up to 60 characters           title

--- a/SRC/slu_mt_cdefs.h
+++ b/SRC/slu_mt_cdefs.h
@@ -468,7 +468,7 @@ extern int_t  Glu_alloc (const int_t, const int_t, const int_t, const MemType,
    -------------------*/
 extern double  SuperLU_timer_();
 extern int_t     sp_ienv(int_t);
-extern double  slamch_();
+extern double  slamch_(char *);
 extern int     lsame_(char *, char *);
 extern int     xerbla_(char *, int *);
 extern void    superlu_abort_and_exit(char *);

--- a/SRC/slu_mt_ddefs.h
+++ b/SRC/slu_mt_ddefs.h
@@ -467,7 +467,7 @@ extern int_t  Glu_alloc (const int_t, const int_t, const int_t, const MemType,
    -------------------*/
 extern double  SuperLU_timer_();
 extern int_t     sp_ienv(int_t);
-extern double  dlamch_();
+extern double  dlamch_(char *);
 extern int     lsame_(char *, char *);
 extern int     xerbla_(char *, int *);
 extern void    superlu_abort_and_exit(char *);

--- a/SRC/slu_mt_sdefs.h
+++ b/SRC/slu_mt_sdefs.h
@@ -467,7 +467,7 @@ extern int_t  Glu_alloc (const int_t, const int_t, const int_t, const MemType,
    -------------------*/
 extern double  SuperLU_timer_();
 extern int_t     sp_ienv(int_t);
-extern double  slamch_();
+extern double  slamch_(char *);
 extern int     lsame_(char *, char *);
 extern int     xerbla_(char *, int *);
 extern void    superlu_abort_and_exit(char *);

--- a/SRC/slu_mt_zdefs.h
+++ b/SRC/slu_mt_zdefs.h
@@ -468,7 +468,7 @@ extern int_t  Glu_alloc (const int_t, const int_t, const int_t, const MemType,
    -------------------*/
 extern double  SuperLU_timer_();
 extern int_t     sp_ienv(int_t);
-extern double  dlamch_();
+extern double  dlamch_(char *);
 extern int     lsame_(char *, char *);
 extern int     xerbla_(char *, int *);
 extern void    superlu_abort_and_exit(char *);

--- a/SRC/sreadmt.c
+++ b/SRC/sreadmt.c
@@ -40,8 +40,8 @@ sreadmt(int_t *m, int_t *n, int_t *nonz, float **nzval, int_t **rowind, int_t **
     int    lasta;
     char   title[TLEN];
     float *a;
-    int    *asub;
-    int    *xa;
+    int_t    *asub;
+    int_t    *xa;
     
     /* 	Matrix format:
      *         up to 60 characters           title

--- a/SRC/zreadmt.c
+++ b/SRC/zreadmt.c
@@ -40,8 +40,8 @@ zreadmt(int_t *m, int_t *n, int_t *nonz, doublecomplex **nzval, int_t **rowind, 
     int    lasta;
     char   title[TLEN];
     doublecomplex *a;
-    int    *asub;
-    int    *xa;
+    int_t    *asub;
+    int_t    *xa;
     
     /* 	Matrix format:
      *         up to 60 characters           title

--- a/TESTING/CMakeLists.txt
+++ b/TESTING/CMakeLists.txt
@@ -20,7 +20,7 @@ function(add_superlumt_test target input)
           	  set(testName "${target}_${p}_${n}_${s}_${l}")
         	  add_test(
 			NAME ${testName}_LA
-          		COMMAND ${target} -t "LA" -n ${n} -s ${s} -l ${l} -p ${p} ) 
+          		COMMAND $<TARGET_FILE:${target}> -t "LA" -n ${n} -s ${s} -l ${l} -p ${p} ) 
       	  endforeach()
 
           # SP tests
@@ -29,7 +29,7 @@ function(add_superlumt_test target input)
           set(testName "${target}_${p}_${s}_${l}")
           add_test(
 		NAME ${testName}_SP
-        	COMMAND sh -c ${target} -t "SP" -s ${s} -l ${l} -p ${p} < ${TEST_INPUT} )
+        	COMMAND sh -c $<TARGET_FILE:${target}> -t "SP" -s ${s} -l ${l} -p ${p} < ${TEST_INPUT} )
       endforeach()
     endforeach()
   endforeach()

--- a/TESTING/pcdrive.c
+++ b/TESTING/pcdrive.c
@@ -9,7 +9,7 @@ The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
 
-#include <string.h>
+#include <strings.h>
 #include "slu_mt_cdefs.h"
 
 #define NTESTS    5    /* Number of test types */
@@ -89,7 +89,9 @@ int main(int argc, char *argv[])
     trans_t trans;
     equed_t equed;
     yes_no_t refact, usepr;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], char *matrix_type,
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork);
 
     /* Fixed set of parameters */
     int      iseed[]  = {1994, 1995, 1996, 1997};
@@ -605,8 +607,8 @@ int main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], char *matrix_type,
-		   int *nprocs, int *n, int *w, int *relax, int *nrhs,
-		   int *maxsuper, int *rowblk, int *colblk, int *lwork)
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork)
 {
     int c;
     extern char *optarg;

--- a/TESTING/pddrive.c
+++ b/TESTING/pddrive.c
@@ -9,7 +9,7 @@ The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
 
-#include <string.h>
+#include <strings.h>
 #include "slu_mt_ddefs.h"
 
 #define NTESTS    5    /* Number of test types */
@@ -89,7 +89,9 @@ int main(int argc, char *argv[])
     trans_t trans;
     equed_t equed;
     yes_no_t refact, usepr;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], char *matrix_type,
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork);
 
     /* Fixed set of parameters */
     int      iseed[]  = {1994, 1995, 1996, 1997};
@@ -605,8 +607,8 @@ int main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], char *matrix_type,
-		   int *nprocs, int *n, int *w, int *relax, int *nrhs,
-		   int *maxsuper, int *rowblk, int *colblk, int *lwork)
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork)
 {
     int c;
     extern char *optarg;

--- a/TESTING/psdrive.c
+++ b/TESTING/psdrive.c
@@ -9,7 +9,7 @@ The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
 
-#include <string.h>
+#include <strings.h>
 #include "slu_mt_sdefs.h"
 
 #define NTESTS    5    /* Number of test types */
@@ -89,7 +89,9 @@ int main(int argc, char *argv[])
     trans_t trans;
     equed_t equed;
     yes_no_t refact, usepr;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], char *matrix_type,
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork);
 
     /* Fixed set of parameters */
     int      iseed[]  = {1994, 1995, 1996, 1997};
@@ -605,8 +607,8 @@ int main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], char *matrix_type,
-		   int *nprocs, int *n, int *w, int *relax, int *nrhs,
-		   int *maxsuper, int *rowblk, int *colblk, int *lwork)
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork)
 {
     int c;
     extern char *optarg;

--- a/TESTING/pzdrive.c
+++ b/TESTING/pzdrive.c
@@ -9,7 +9,7 @@ The source code is distributed under BSD license, see the file License.txt
 at the top-level directory.
 */
 
-#include <string.h>
+#include <strings.h>
 #include "slu_mt_zdefs.h"
 
 #define NTESTS    5    /* Number of test types */
@@ -89,7 +89,9 @@ int main(int argc, char *argv[])
     trans_t trans;
     equed_t equed;
     yes_no_t refact, usepr;
-    void parse_command_line();
+    void parse_command_line(int argc, char *argv[], char *matrix_type,
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork);
 
     /* Fixed set of parameters */
     int      iseed[]  = {1994, 1995, 1996, 1997};
@@ -605,8 +607,8 @@ int main(int argc, char *argv[])
  */
 void
 parse_command_line(int argc, char *argv[], char *matrix_type,
-		   int *nprocs, int *n, int *w, int *relax, int *nrhs,
-		   int *maxsuper, int *rowblk, int *colblk, int *lwork)
+		   int_t *nprocs, int_t *n, int_t *w, int_t *relax, int_t *nrhs,
+		   int_t *maxsuper, int_t *rowblk, int_t *colblk, int_t *lwork)
 {
     int c;
     extern char *optarg;


### PR DESCRIPTION
Also fixes a lot of prototypes issues, now builds fine with both LONGINT=OFF & ON
If we could have a new version with this I would be so happy.